### PR TITLE
Fix Wayland OpenGL loader crash, resolve empty device name ImGui ID collision, and add Sony ULT WEAR support

### DIFF
--- a/Client/CMakeLists.txt
+++ b/Client/CMakeLists.txt
@@ -1,5 +1,5 @@
+cmake_minimum_required(VERSION 3.5)
 project(SonyHeadphonesClient)
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 
 set(CMAKE_CXX_STANDARD 20)
 
@@ -59,16 +59,14 @@ if (LINUX)
 	
     find_package(DBus REQUIRED)
 
-    find_package(GLEW REQUIRED)
-
     find_package(glfw3 REQUIRED)
 
     find_package(OpenGL REQUIRED)
 
-    if ((NOT DBUS_FOUND) OR (NOT GLEW_FOUND) OR (NOT glfw3_FOUND) OR (NOT OPENGL_FOUND))
+    if ((NOT DBUS_FOUND) OR (NOT glfw3_FOUND) OR (NOT OPENGL_FOUND))
         message ( FATAL_ERROR 
         "Didn't find one of the packages. For Debian based systems, use:"
-        "sudo apt install libbluetooth-dev libglew-dev libglfw3-dev libdbus-1-dev" )
+        "sudo apt install libbluetooth-dev libglfw3-dev libdbus-1-dev" )
     endif ()
 
     target_include_directories(SonyHeadphonesClient
@@ -78,7 +76,6 @@ if (LINUX)
 
     target_link_libraries(SonyHeadphonesClient
         PRIVATE ${DBUS_LIBRARIES}
-        GLEW::GLEW 
         glfw
         bluetooth
         OpenGL::GL

--- a/Client/CrossPlatformGUI.cpp
+++ b/Client/CrossPlatformGUI.cpp
@@ -1,4 +1,4 @@
-﻿#include "CrossPlatformGUI.h"
+#include "CrossPlatformGUI.h"
 
 bool CrossPlatformGUI::performGUIPass()
 {
@@ -78,7 +78,8 @@ void CrossPlatformGUI::_drawDeviceDiscovery()
 			int temp = 0;
 			for (const auto& device : connectedDevices)
 			{
-				ImGui::RadioButton(device.name.c_str(), &selectedDevice, temp++);
+				std::string label = (device.name.empty() ? "Unknown Device" : device.name) + "##" + device.mac;
+				ImGui::RadioButton(label.c_str(), &selectedDevice, temp++);
 			}
 
 			ImGui::Spacing();

--- a/Client/linux/LinuxGUI.cpp
+++ b/Client/linux/LinuxGUI.cpp
@@ -2,7 +2,6 @@
 #include "imgui.h"
 #include "backends/imgui_impl_glfw.h"
 #include "backends/imgui_impl_opengl3.h"
-#include <GL/glew.h>
 #include <GLFW/glfw3.h>
 #include <stdio.h>
 #include "Constants.h"
@@ -28,9 +27,11 @@ void EnterGUIMainLoop(BluetoothWrapper bt)
     if (!glfwInit())
         return;
 
-    const char *glsl_version = "#version 130";
+    const char *glsl_version = "#version 150";
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+    glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
 
     // Create window with graphics context
     GLFWwindow *window = glfwCreateWindow(GUI_WIDTH, GUI_HEIGHT, APP_NAME, NULL, NULL);
@@ -39,13 +40,6 @@ void EnterGUIMainLoop(BluetoothWrapper bt)
 
     glfwMakeContextCurrent(window);
     glfwSwapInterval(1); // Enable vsync
-
-    bool err = glewInit() != GLEW_OK;
-    if (err)
-    {
-        fprintf(stderr, "Failed to initialize OpenGL loader!\n");
-        return;
-    }
 
     ImGuiIO &io = ImGui::GetIO();
     (void)io;

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ interface built for those devices.
 
 | Status | Devices |
 |--------|---------|
-| ✅ **Verified** | WH-CH720N |
+| ✅ **Verified** | WH-CH720N, Sony ULT WEAR (WH-ULT900N) |
 | 🟢 **Expected** (v2, over-ear — NC/Ambient/battery/EQ) | WH-1000XM5, WH-1000XM6, WH-XB910N, WH-CH520 |
 | 🟡 **v2 earbuds** (controls work; battery format differs) | WF-1000XM4, WF-1000XM5, WF-C700N, LinkBuds S |
 | 🔵 **Legacy** (v1 protocol — NC/Ambient only) | WH-1000XM4, WH-1000XM3, WH-1000XM2, WH-XB900N, MDR-XB950BT |
@@ -137,7 +137,7 @@ Sony headphones expose a vendor RFCOMM/SPP service. Commands are framed as:
 Two protocol generations exist, distinguished by their SDP service UUID:
 
 - **v1** — `96CC203E-…` — WH-1000XM3 and older
-- **v2** — `956C7B26-…` — WH-CH720N, XM4/XM5, WF-series, LinkBuds…
+- **v2** — `956C7B26-…` — WH-CH720N, Sony ULT WEAR (WH-ULT900N), XM4/XM5, WF-series, LinkBuds…
 
 SonyBridge tries v1 first, falls back to v2, and remembers which succeeded. The v2 path adds the
 mandatory init handshake and per-frame host-ACK the newer devices require, plus battery and equalizer


### PR DESCRIPTION
This PR resolves two major crash issues on Linux/Wayland and documents support for the Sony ULT WEAR (WH-ULT900N) headphones:

1. **GLEW Removal & OpenGL 3.3 Core Upgrade**: Removes the buggy GLEW dependency and upgrades GLFW window context hints to request OpenGL 3.3 Core Profile with forward compatibility, resolving startup crashes on modern Wayland compositors (like COSMIC).
2. **ImGui ID Collision Fix**: Safely maps empty Bluetooth device names to 'Unknown Device' and appends MAC suffixes via ImGui's ID stack (##) to avoid root-level window ID collisions during device discovery.
3. **Sony ULT WEAR Support**: Adds the Sony ULT WEAR to the list of verified devices in the README.